### PR TITLE
Add MX queries, Happy Eyeballs connect, multi-window rate limiter

### DIFF
--- a/src/powpow/net/dns.nim
+++ b/src/powpow/net/dns.nim
@@ -40,6 +40,7 @@ const
   DnsRecvBufSize      = 2048
   DnsMaxLabelJumps    = 128
   DnsQtypeA           = 1'u16
+  DnsQtypeMX          = 15'u16
   DnsQtypeAAAA        = 28'u16
 
 when defined(windows):
@@ -51,6 +52,12 @@ else:
 type
   DnsCallback* = proc(addrs: seq[Sockaddr_storage]; err: string) {.closure.}
 
+  MxRecord* = object
+    pref*: int
+    exchange*: string
+
+  MxCallback* = proc(records: seq[MxRecord]; err: string) {.closure.}
+
   ResolvedIp* = object
     af: cint
     addr4: array[4, byte]
@@ -58,6 +65,7 @@ type
 
   DnsCacheEntry* = object
     addrs: seq[ResolvedIp]
+    mxs: seq[MxRecord]
     expiresAt: int64
     negative: bool
 
@@ -68,6 +76,7 @@ type
     sockType: cint
     qtype: uint16
     cb: DnsCallback
+    mcb: MxCallback
     resolver: DnsResolver
     server: Sockaddr_storage   ## nameserver the query is currently directed at
     serverIdx: int
@@ -185,40 +194,73 @@ proc skipName(msg: openArray[byte]; start: int): int =
     if pos > msg.len: return -1
   return -1
 
+proc readName(msg: openArray[byte]; start: int): tuple[name: string, next: int] =
+  ## Decode a (possibly compressed) domain name starting at `start`.
+  ## Returns the decoded name (no trailing dot) and the position just past the
+  ## name in the original stream, or ("", -1) on malformed data. Pointers are
+  ## bounded by DnsMaxLabelJumps to defeat compression loops.
+  var parts: seq[string]
+  var pos = start
+  var next = -1
+  var jumps = 0
+  while pos < msg.len:
+    let b = msg[pos]
+    if b == 0:
+      if next < 0: next = pos + 1
+      return (parts.join("."), next)
+    if (b and 0xC0) == 0xC0:
+      if pos + 1 >= msg.len: return ("", -1)
+      if next < 0: next = pos + 2
+      inc jumps
+      if jumps > DnsMaxLabelJumps: return ("", -1)
+      pos = ((b.int and 0x3F) shl 8) or msg[pos + 1].int
+      continue
+    if (b and 0xC0) != 0:
+      return ("", -1)
+    if pos + 1 + b.int > msg.len: return ("", -1)
+    var label = newString(b.int)
+    for i in 0 ..< b.int:
+      label[i] = chr(msg[pos + 1 + i])
+    parts.add(label)
+    pos += 1 + b.int
+  return ("", -1)
+
 proc parseResponse(msg: openArray[byte]):
-    tuple[rcode: int, addrs: seq[ResolvedIp], minTtl: int, truncated: bool] =
+    tuple[rcode: int, addrs: seq[ResolvedIp], mxs: seq[MxRecord], minTtl: int, truncated: bool] =
   ## Parse a DNS response. Returns the rcode (0 = NOERROR), the A/AAAA
-  ## addresses found, the smallest answer TTL, and whether the TC bit was set.
+  ## addresses found, any MX records, the smallest answer TTL, and whether the
+  ## TC bit was set.
   if msg.len < 12:
-    return (1, newSeq[ResolvedIp](), 0, false)
+    return (1, newSeq[ResolvedIp](), newSeq[MxRecord](), 0, false)
   let flags = (uint16(msg[2]) shl 8) or msg[3]
   if (flags and 0x8000) == 0:
-    return (1, newSeq[ResolvedIp](), 0, false)   # not a response
+    return (1, newSeq[ResolvedIp](), newSeq[MxRecord](), 0, false)   # not a response
   let truncated = (flags and 0x0200) != 0
   let rcode = int(flags and 0x0F)
   if rcode != 0:
-    return (rcode, newSeq[ResolvedIp](), 0, truncated)
+    return (rcode, newSeq[ResolvedIp](), newSeq[MxRecord](), 0, truncated)
   let qd = int(msg[4]) shl 8 or int(msg[5])
   let an = int(msg[6]) shl 8 or int(msg[7])
   var pos = 12
   for i in 0 ..< qd:
     pos = skipName(msg, pos)
-    if pos < 0: return (1, newSeq[ResolvedIp](), 0, truncated)
+    if pos < 0: return (1, newSeq[ResolvedIp](), newSeq[MxRecord](), 0, truncated)
     pos += 4
   var addrs: seq[ResolvedIp]
+  var mxs: seq[MxRecord]
   var minTtl = 60
   var haveTtl = false
   for i in 0 ..< an:
     pos = skipName(msg, pos)
-    if pos < 0: return (1, newSeq[ResolvedIp](), 0, truncated)
-    if pos + 10 > msg.len: return (1, newSeq[ResolvedIp](), 0, truncated)
+    if pos < 0: return (1, newSeq[ResolvedIp](), newSeq[MxRecord](), 0, truncated)
+    if pos + 10 > msg.len: return (1, newSeq[ResolvedIp](), newSeq[MxRecord](), 0, truncated)
     let qtype = (uint16(msg[pos]) shl 8) or msg[pos + 1]
     let qclass = (uint16(msg[pos + 2]) shl 8) or msg[pos + 3]
     let ttl = (int(msg[pos + 4]) shl 24) or (int(msg[pos + 5]) shl 16) or
               (int(msg[pos + 6]) shl 8) or int(msg[pos + 7])
     let rdlen = (int(msg[pos + 8]) shl 8) or int(msg[pos + 9])
     pos += 10
-    if pos + rdlen > msg.len: return (1, newSeq[ResolvedIp](), 0, truncated)
+    if pos + rdlen > msg.len: return (1, newSeq[ResolvedIp](), newSeq[MxRecord](), 0, truncated)
     if qclass == 1:
       if not haveTtl or ttl < minTtl:
         minTtl = ttl
@@ -233,8 +275,13 @@ proc parseResponse(msg: openArray[byte]):
         ip.af = AF_INET6.cint
         copyMem(addr ip.addr6[0], addr msg[pos], 16)
         addrs.add(ip)
+      elif qtype == DnsQtypeMX and rdlen >= 3:
+        let pref = (int(msg[pos]) shl 8) or msg[pos + 1].int
+        let (name, _) = readName(msg, pos + 2)
+        if name.len > 0:
+          mxs.add(MxRecord(pref: pref, exchange: name.toLowerAscii()))
     pos += rdlen
-  result = (0, addrs, minTtl, truncated)
+  result = (0, addrs, mxs, minTtl, truncated)
 
 # ── System config ─────────────────────────────────────────────────────────────
 
@@ -317,6 +364,15 @@ proc defaultNameservers(): seq[ResolvedIp] =
 
 # ── Resolver internals ────────────────────────────────────────────────────────
 
+proc cacheKey(hostname: string; qtype: uint16): string =
+  ## Cache entries are keyed by record type so A/AAAA/MX answers for the same
+  ## name never collide.
+  case qtype
+  of DnsQtypeA: "a/" & hostname.toLowerAscii()
+  of DnsQtypeAAAA: "aaaa/" & hostname.toLowerAscii()
+  of DnsQtypeMX: "mx/" & hostname.toLowerAscii()
+  else: "q" & $qtype & "/" & hostname.toLowerAscii()
+
 proc nextQueryId(resolver: DnsResolver): uint16 =
   while true:
     inc resolver.nextId
@@ -337,21 +393,29 @@ proc sendQuery(q: DnsQuery) =
     discard sendto(resolver.fd, unsafeAddr msg[0], msg.len.cint, 0,
                    cast[ptr Sockaddr](addr server), sLen)
 
-proc completeQuery(q: DnsQuery; addrs: seq[ResolvedIp]; err: string) =
+proc completeQuery(q: DnsQuery; addrs: seq[ResolvedIp]; mxs: seq[MxRecord]; err: string) =
   if q.done: return
   q.done = true
   q.resolver.queries.del(q.id)
   if q.timer != TimerId(0):
     q.resolver.loop.cancelTimer(q.timer)
     q.timer = TimerId(0)
-  if err.len == 0 and addrs.len > 0:
+  if err.len == 0 and q.mcb != nil:
+    # MX query: an empty answer is a valid result (the caller decides whether
+    # to fall back to address resolution, e.g. RFC 5321 §5.1).
+    q.mcb(mxs, "")
+  elif err.len == 0 and addrs.len > 0:
     var outAddrs: seq[Sockaddr_storage]
     for ip in addrs:
       outAddrs.add(makeSockaddr(ip, q.port))
     q.cb(outAddrs, "")
   else:
-    q.cb(newSeq[Sockaddr_storage](),
-         if err.len > 0: err else: "DNS: no addresses for " & q.hostname)
+    if q.mcb != nil:
+      q.mcb(newSeq[MxRecord](),
+           if err.len > 0: err else: "DNS: no records for " & q.hostname)
+    else:
+      q.cb(newSeq[Sockaddr_storage](),
+           if err.len > 0: err else: "DNS: no addresses for " & q.hostname)
 
 proc startQuery(resolver: DnsResolver; hostname: string; port: int; sockType: cint;
                 qtype: uint16; cb: DnsCallback)
@@ -377,36 +441,49 @@ proc onTimeout(q: DnsQuery) =
     q.sendQuery()
     q.timer = q.resolver.loop.addTimer(q.resolver.timeoutMs) do (tid: int):
       onTimeout(q)
-  elif q.qtype == DnsQtypeAAAA:
+  elif q.qtype == DnsQtypeAAAA and q.mcb == nil:
     startAFallback(q)
   else:
-    q.completeQuery(newSeq[ResolvedIp](), "DNS: timed out resolving " & q.hostname)
+    q.completeQuery(newSeq[ResolvedIp](), newSeq[MxRecord](),
+                    "DNS: timed out resolving " & q.hostname)
 
 proc onDnsResponse(q: DnsQuery; msg: openArray[byte]) =
   if q.done: return
-  let (rcode, addrs, minTtl, truncated) = parseResponse(msg)
+  let (rcode, addrs, mxs, minTtl, truncated) = parseResponse(msg)
   let resolver = q.resolver
-  let key = q.hostname.toLowerAscii()
+  let key = cacheKey(q.hostname, q.qtype)
   if truncated:
-    q.completeQuery(newSeq[ResolvedIp](),
+    q.completeQuery(newSeq[ResolvedIp](), newSeq[MxRecord](),
       "DNS: truncated response for " & q.hostname & " (TCP fallback not implemented)")
     return
   if rcode != 0:
     if rcode == 3:
       resolver.cache[key] =
         DnsCacheEntry(addrs: @[], expiresAt: monoMs() + NegativeCacheMs, negative: true)
-    q.completeQuery(newSeq[ResolvedIp](),
-      "DNS: " & (if rcode == 3: "host not found: " else: "query failed (rcode " & $rcode & "): ") &
-      q.hostname)
-  elif addrs.len > 0:
-    resolver.cache[key] =
-      DnsCacheEntry(addrs: addrs, expiresAt: monoMs() + int64(minTtl) * 1000, negative: false)
-    q.completeQuery(addrs, "")
-  elif q.qtype == DnsQtypeAAAA:
+    let msg = "DNS: " & (if rcode == 3: "host not found: " else: "query failed (rcode " & $rcode & "): ") &
+      q.hostname
+    q.completeQuery(newSeq[ResolvedIp](), newSeq[MxRecord](), msg)
+  elif addrs.len > 0 or (q.mcb != nil and mxs.len > 0):
+    if q.mcb != nil:
+      resolver.cache[key] =
+        DnsCacheEntry(mxs: mxs, expiresAt: monoMs() + int64(minTtl) * 1000, negative: false)
+      q.completeQuery(newSeq[ResolvedIp](), mxs, "")
+    else:
+      resolver.cache[key] =
+        DnsCacheEntry(addrs: addrs, expiresAt: monoMs() + int64(minTtl) * 1000, negative: false)
+      q.completeQuery(addrs, newSeq[MxRecord](), "")
+  elif q.qtype == DnsQtypeAAAA and q.mcb == nil:
     # Name exists but has no AAAA records — fall back to A.
     startAFallback(q)
   else:
-    q.completeQuery(newSeq[ResolvedIp](), "DNS: no addresses for " & q.hostname)
+    # NOERROR with no usable records. For MX this is a valid empty answer;
+    # for address queries it means the name exists without A records.
+    if q.mcb != nil:
+      resolver.cache[key] =
+        DnsCacheEntry(mxs: @[], expiresAt: monoMs() + int64(minTtl) * 1000, negative: false)
+      q.completeQuery(newSeq[ResolvedIp](), newSeq[MxRecord](), "")
+    else:
+      q.completeQuery(newSeq[ResolvedIp](), newSeq[MxRecord](), "DNS: no addresses for " & q.hostname)
 
 proc startQuery(resolver: DnsResolver; hostname: string; port: int; sockType: cint;
                 qtype: uint16; cb: DnsCallback) =
@@ -417,6 +494,22 @@ proc startQuery(resolver: DnsResolver; hostname: string; port: int; sockType: ci
   let q = DnsQuery(
     id: id, hostname: hostname, port: port, sockType: sockType,
     qtype: qtype, cb: cb, resolver: resolver,
+    serverIdx: 0, attemptsLeft: resolver.attempts, timer: TimerId(0),
+    done: false,
+  )
+  resolver.queries[id] = q
+  q.sendQuery()
+  q.timer = resolver.loop.addTimer(resolver.timeoutMs) do (tid: int):
+    onTimeout(q)
+
+proc startMxQuery(resolver: DnsResolver; domain: string; mcb: MxCallback) =
+  if resolver.queries.len >= MaxOutstandingQueries:
+    mcb(newSeq[MxRecord](), "DNS: too many outstanding queries")
+    return
+  let id = resolver.nextQueryId()
+  let q = DnsQuery(
+    id: id, hostname: domain, port: 0, sockType: 0,
+    qtype: DnsQtypeMX, mcb: mcb, resolver: resolver,
     serverIdx: 0, attemptsLeft: resolver.attempts, timer: TimerId(0),
     done: false,
   )
@@ -555,24 +648,27 @@ proc resolveAddrAsync*(loop: Loop; address: string; port: int;
     cb(@[addrBuf], "")
     return
 
-  let key = address.toLowerAscii()
+  let name = address.toLowerAscii()
 
   if loop.dns != nil:
     let r = cast[DnsResolver](loop.dns)
-    let cached = r.cache.getOrDefault(key)
-    if cached.addrs.len > 0 or cached.negative:
-      if cached.expiresAt > monoMs():
-        if cached.negative:
-          cb(newSeq[Sockaddr_storage](), "DNS: host not found: " & address)
-        else:
-          var outAddrs: seq[Sockaddr_storage]
-          for ip in cached.addrs:
-            outAddrs.add(makeSockaddr(ip, port))
-          cb(outAddrs, "")
-        return
-      r.cache.del(key)
+    # The single-family path prefers AAAA but may have fallen back to A in a
+    # previous resolution, so consult both family caches.
+    for qtype in [DnsQtypeAAAA, DnsQtypeA]:
+      let cached = r.cache.getOrDefault(cacheKey(name, qtype))
+      if cached.addrs.len > 0 or cached.negative:
+        if cached.expiresAt > monoMs():
+          if cached.negative:
+            cb(newSeq[Sockaddr_storage](), "DNS: host not found: " & address)
+          else:
+            var outAddrs: seq[Sockaddr_storage]
+            for ip in cached.addrs:
+              outAddrs.add(makeSockaddr(ip, port))
+            cb(outAddrs, "")
+          return
+        r.cache.del(cacheKey(name, qtype))
 
-  let h = getHosts().getOrDefault(key)
+  let h = getHosts().getOrDefault(name)
   if h.len > 0:
     var outAddrs: seq[Sockaddr_storage]
     for ip in h:
@@ -587,6 +683,152 @@ proc resolveAddrAsync*(loop: Loop; address: string; port: int;
     cb(newSeq[Sockaddr_storage](), e.msg)
     return
   startQuery(resolver, address, port, sockType, DnsQtypeAAAA, cb)
+
+proc resolveMxAsync*(loop: Loop; domain: string; mcb: MxCallback) =
+  ## Resolve MX records for `domain` asynchronously on `loop`. `mcb` runs on
+  ## the loop thread with the records sorted by ascending preference (or an
+  ## empty seq when the name exists but publishes no MX — callers decide
+  ## whether to fall back to address resolution, e.g. RFC 5321 §5.1). A
+  ## non-empty `err` signals NXDOMAIN or a resolver failure. Never blocks the
+  ## loop on DNS.
+  let key = cacheKey(domain, DnsQtypeMX)
+  if loop.dns != nil:
+    let r = cast[DnsResolver](loop.dns)
+    let cached = r.cache.getOrDefault(key)
+    if cached.expiresAt != 0:
+      if cached.expiresAt > monoMs():
+        if cached.negative:
+          mcb(newSeq[MxRecord](), "DNS: host not found: " & domain)
+        else:
+          mcb(cached.mxs, "")
+        return
+      r.cache.del(key)
+
+  var resolver: DnsResolver
+  try:
+    resolver = loop.getResolver()
+  except CatchableError as e:
+    mcb(newSeq[MxRecord](), e.msg)
+    return
+  startMxQuery(resolver, domain, mcb)
+
+proc resolveAddrBothAsync*(loop: Loop; address: string; port: int;
+                           cb: DnsCallback) =
+  ## Resolve both address families for `address` and deliver all socket
+  ## addresses ordered IPv6-first (RFC 8305 family-block order) — the input
+  ## for Happy Eyeballs connection attempts. If one family fails or is
+  ## empty, the other is still delivered; only when both yield nothing does
+  ## `cb` fire with an error. Never blocks the loop on DNS.
+  if isIpAddress(address):
+    var addrBuf: Sockaddr_storage
+    try:
+      addrBuf = sockaddrFromIp(address, port)
+    except NetError as e:
+      cb(newSeq[Sockaddr_storage](), e.msg)
+      return
+    cb(@[addrBuf], "")
+    return
+
+  let key = "both/" & address.toLowerAscii()
+
+  if loop.dns != nil:
+    let r = cast[DnsResolver](loop.dns)
+    let cached = r.cache.getOrDefault(key)
+    if cached.expiresAt != 0:
+      if cached.expiresAt > monoMs():
+        if cached.negative:
+          cb(newSeq[Sockaddr_storage](), "DNS: host not found: " & address)
+        else:
+          var outAddrs: seq[Sockaddr_storage]
+          for ip in cached.addrs:
+            outAddrs.add(makeSockaddr(ip, port))
+          cb(outAddrs, "")
+        return
+      r.cache.del(key)
+
+  let h = getHosts().getOrDefault(address.toLowerAscii())
+  if h.len > 0:
+    var outAddrs: seq[Sockaddr_storage]
+    for ip in h:
+      outAddrs.add(makeSockaddr(ip, port))
+    cb(outAddrs, "")
+    return
+
+  var resolver: DnsResolver
+  try:
+    resolver = loop.getResolver()
+  except CatchableError as e:
+    cb(newSeq[Sockaddr_storage](), e.msg)
+    return
+
+  # Fire AAAA and A queries concurrently and merge when both settle.
+  type BothState = ref object
+    pending: int
+    v6: seq[ResolvedIp]
+    v4: seq[ResolvedIp]
+    errAaaa: string
+    errA: string
+    finished: bool
+
+  let bs = BothState(pending: 2)
+
+  proc finish() {.closure.} =
+    if bs.finished: return
+    bs.finished = true
+    if bs.v6.len == 0 and bs.v4.len == 0:
+      var err = if bs.errA.len > 0: bs.errA else: bs.errAaaa
+      if err.len == 0:
+        err = "DNS: no addresses for " & address
+      cb(newSeq[Sockaddr_storage](), err)
+      return
+    # Cache the merged list under a short TTL (the per-family entries carry
+    # their own authoritative TTLs; the merge itself is refreshed often).
+    if loop.dns != nil:
+      let r = cast[DnsResolver](loop.dns)
+      r.cache[key] = DnsCacheEntry(
+        addrs: bs.v6 & bs.v4,
+        expiresAt: monoMs() + 60_000,
+        negative: false,
+      )
+    var merged: seq[Sockaddr_storage]
+    for ip in bs.v6: merged.add(makeSockaddr(ip, port))
+    for ip in bs.v4: merged.add(makeSockaddr(ip, port))
+    cb(merged, "")
+
+  proc settle(qtype: uint16; addrs: seq[Sockaddr_storage]; err: string) {.closure.} =
+    if qtype == DnsQtypeAAAA:
+      dec bs.pending
+      if err.len == 0:
+        for sa in addrs:
+          if sa.ss_family == AF_INET6.cushort:
+            var ip: ResolvedIp
+            ip.af = AF_INET6.cint
+            let s6 = cast[ptr Sockaddr_in6](unsafeAddr sa)
+            copyMem(addr ip.addr6[0], addr s6.sin6_addr, 16)
+            bs.v6.add(ip)
+      else:
+        bs.errAaaa = err
+    else:
+      dec bs.pending
+      if err.len == 0:
+        for sa in addrs:
+          if sa.ss_family == AF_INET.cushort:
+            var ip: ResolvedIp
+            ip.af = AF_INET.cint
+            let s4 = cast[ptr Sockaddr_in](unsafeAddr sa)
+            copyMem(addr ip.addr4[0], addr s4.sin_addr, 4)
+            bs.v4.add(ip)
+      else:
+        bs.errA = err
+    if bs.pending == 0:
+      finish()
+
+  startQuery(resolver, address, port, SOCK_STREAM, DnsQtypeAAAA,
+             proc(addrs: seq[Sockaddr_storage]; err: string) {.closure.} =
+               settle(DnsQtypeAAAA, addrs, err))
+  startQuery(resolver, address, port, SOCK_STREAM, DnsQtypeA,
+             proc(addrs: seq[Sockaddr_storage]; err: string) {.closure.} =
+               settle(DnsQtypeA, addrs, err))
 
 proc configureDns*(loop: Loop; timeoutMs: int; attempts: int) =
   ## Override the resolver's timeout/attempts (e.g. for tests). Values <= 0

--- a/src/powpow/net/tcp.nim
+++ b/src/powpow/net/tcp.nim
@@ -248,6 +248,36 @@ proc getClientSockAddr*(conn: Connection): Sockaddr_storage {.inline.} =
   ## Return the client's raw socket address (set at accept/connect time).
   conn.clientAddr
 
+# ── Happy Eyeballs (RFC 6555 / RFC 8305) ─────────────────────────────────────
+#
+# Client connects race the resolved address list instead of walking it
+# sequentially: the first attempt starts immediately and every further
+# address joins ConnectionAttemptDelayMs later while earlier attempts are
+# still in flight. The first successful connect wins; all other attempts are
+# torn down. The scheduling core below is shared by both backends — each
+# backend's `connect` supplies only the per-attempt socket/connect
+# initiation and completion plumbing.
+
+const ConnectionAttemptDelayMs = 250
+
+type
+  HeAttempt = ref object
+    idx: int                # index into HeState.addrs
+    conn: Connection        # nil until the socket is created
+    timer: TimerId          # per-attempt connect timeout
+    dead: bool              # failed / timed out / torn down
+
+  HeState = ref object
+    loop: Loop
+    host: string            # original hostname (for error messages)
+    addrs: seq[Sockaddr_storage]   # RFC 8305 ordered (IPv6-first)
+    nextIdx: int            # next address index to start
+    staggerTimer: TimerId   # inter-attempt delay timer
+    attempts: seq[HeAttempt]
+    finished: bool          # a terminal outcome was delivered
+    onConnect: proc(conn: Connection) {.closure.}
+    onError: OnError
+
 when iouEnabled:
   import ./tlsapi
 
@@ -1982,6 +2012,171 @@ when iouEnabled:
         attemptNext()
     )
 
+  # ── Client connect — Happy Eyeballs (RFC 6555) ─────────────────────────────
+
+  proc connectHe*(loop: Loop, address: string, port: int,
+                  onConnect: proc(conn: Connection) {.closure.},
+                  onData: OnData,
+                  onClose: OnClose = nil,
+                  onError: OnError = nil) =
+    ## Non-blocking TCP connect with Happy Eyeballs (RFC 6555): both address
+    ## families are resolved, the first attempt starts immediately and further
+    ## addresses join every ConnectionAttemptDelayMs while earlier attempts are
+    ## still connecting. The first successful connect wins.
+    resolveAddrBothAsync(loop, address, port,
+      proc(addrs: seq[Sockaddr_storage]; err: string) =
+        if err.len > 0:
+          if onError != nil:
+            onError(err)
+          return
+        if addrs.len == 0:
+          if onError != nil:
+            onError("connect: no addresses resolved for " & address)
+          return
+
+        let he = HeState(
+          loop: loop, host: address, addrs: addrs,
+          onConnect: onConnect, onError: onError,
+        )
+
+        proc failAll() {.closure.} =
+          if he.finished: return
+          he.finished = true
+          if he.staggerTimer != TimerId(0):
+            loop.cancelTimer(he.staggerTimer)
+            he.staggerTimer = TimerId(0)
+          if onError != nil:
+            onError("connect() failed on all resolved addresses for " & address)
+
+        proc attemptDead(a: HeAttempt) {.closure.} =
+          if a.dead: return
+          a.dead = true
+          if a.timer != TimerId(0):
+            loop.cancelTimer(a.timer)
+            a.timer = TimerId(0)
+          if he.finished: return
+          if he.nextIdx >= he.addrs.len:
+            for o in he.attempts:
+              if not o.dead: return
+            failAll()
+
+        proc reportSuccess(a: HeAttempt): bool {.closure.} =
+          if he.finished:
+            a.dead = true
+            if a.timer != TimerId(0):
+              loop.cancelTimer(a.timer)
+              a.timer = TimerId(0)
+            return false
+          he.finished = true
+          if he.staggerTimer != TimerId(0):
+            loop.cancelTimer(he.staggerTimer)
+            he.staggerTimer = TimerId(0)
+          for o in he.attempts:
+            if o != a and not o.dead:
+              o.dead = true
+              if o.timer != TimerId(0):
+                loop.cancelTimer(o.timer)
+                o.timer = TimerId(0)
+              if o.conn != nil:
+                o.conn.closeAndRelease()
+                o.conn = nil
+          a.dead = true
+          if a.timer != TimerId(0):
+            loop.cancelTimer(a.timer)
+            a.timer = TimerId(0)
+          return true
+
+        proc armTimeout(a: HeAttempt) {.closure.} =
+          a.timer = loop.addTimer(ConnectTimeoutMs) do (id: int):
+            a.timer = TimerId(0)
+            if a.dead or he.finished: return
+            if a.conn != nil:
+              a.conn.closeAndRelease()
+              a.conn = nil
+            attemptDead(a)
+
+        proc armStagger() {.closure.} =
+          he.staggerTimer = loop.addTimer(ConnectionAttemptDelayMs) do (id: int):
+            he.staggerTimer = TimerId(0)
+            if he.finished: return
+            if he.nextIdx < he.addrs.len:
+              let i = he.nextIdx
+              inc he.nextIdx
+              startOne(i)
+              if he.nextIdx < he.addrs.len:
+                armStagger()
+
+        proc startOne(idx: int) {.closure.} =
+          let addrBuf = he.addrs[idx]
+          let a = HeAttempt(idx: idx)
+          he.attempts.add(a)
+
+          let fd = socket(cast[ptr Sockaddr](addr addrBuf).sa_family.cint,
+                          SOCK_STREAM, 0)
+          if fd.cint < 0:
+            attemptDead(a)
+            return
+
+          setNonBlocking(fd)
+          setTcpNoDelay(fd)
+
+          let conn = Connection(
+            fd:        fd,
+            loop:      loop,
+            state:     Connecting,
+            readBuf:   acquireBuf(loop),
+            readBufLen: DefaultBufSize,
+            onDataCb:  onData,
+            onCloseCb: onClose,
+            splicePipe: [-1.cint, -1.cint],
+          )
+          conn.initOpCallbacks()
+          a.conn = conn
+          let sLen = getSockLen(addr addrBuf)
+          conn.connectAddr = addrBuf
+          conn.fixedFd = loop.registerFixedFd(fd.int)
+          let cSqe = loop.getOpSqe()
+          if cSqe == nil:
+            conn.closeAndRelease()
+            attemptDead(a)
+            return
+          cSqe.opcode = IORING_OP_CONNECT.uint8
+          cSqe.fd = fd.int32
+          if conn.fixedFd:
+            cSqe.flags = IOSQE_FIXED_FILE.uint8
+          cSqe.paddr = cast[uint64](addr conn.connectAddr)
+          cSqe.off = sLen.uint64   # kernel 5.15: sockaddr length in addr2 (offset 8)
+          conn.connectToken = loop.commitOp(cSqe, proc(token: uint64, res: int32, flags: uint32) =
+              if conn.connectToken != token:
+                return
+              conn.connectToken = 0
+              if conn.state == Closed:
+                return
+              if res < 0:
+                conn.closeAndRelease()
+                attemptDead(a)
+                return
+              if reportSuccess(a):
+                conn.state = Connected
+                conn.clientAddr = addrBuf
+                onConnect(conn)
+                if conn.state == Closed:
+                  return
+                conn.armRead()
+              else:
+                conn.closeAndRelease())
+          if conn.connectToken == 0:
+            conn.closeAndRelease()
+            attemptDead(a)
+            return
+          armTimeout(a)
+
+        he.nextIdx = 1
+        startOne(0)
+        if not he.finished and he.nextIdx < he.addrs.len:
+          armStagger()
+    )
+
   when not defined(windows):
     proc connectUnix*(loop: Loop; path: string;
                       onConnect: proc(conn: Connection) {.closure.};
@@ -2966,6 +3161,213 @@ else:
               conn.closeAndRelease()
               attemptNext()
         attemptNext()
+    )
+
+  # ── Client connect — Happy Eyeballs (RFC 6555) ─────────────────────────────
+
+  proc connectHe*(loop: Loop, address: string, port: int,
+                  onConnect: proc(conn: Connection) {.closure.},
+                  onData: OnData,
+                  onClose: OnClose = nil,
+                  onError: OnError = nil) =
+    ## Non-blocking TCP connect with Happy Eyeballs (RFC 6555): both address
+    ## families are resolved, the first attempt starts immediately and further
+    ## addresses join every ConnectionAttemptDelayMs while earlier attempts are
+    ## still connecting. The first successful connect wins.
+    resolveAddrBothAsync(loop, address, port,
+      proc(addrs: seq[Sockaddr_storage]; err: string) =
+        if err.len > 0:
+          if onError != nil:
+            onError(err)
+          return
+        if addrs.len == 0:
+          if onError != nil:
+            onError("connect: no addresses resolved for " & address)
+          return
+
+        let he = HeState(
+          loop: loop, host: address, addrs: addrs,
+          onConnect: onConnect, onError: onError,
+        )
+
+        proc failAll() {.closure.} =
+          if he.finished: return
+          he.finished = true
+          if he.staggerTimer != TimerId(0):
+            loop.cancelTimer(he.staggerTimer)
+            he.staggerTimer = TimerId(0)
+          if onError != nil:
+            onError("connect() failed on all resolved addresses for " & address)
+
+        proc attemptDead(a: HeAttempt) {.closure.} =
+          if a.dead: return
+          a.dead = true
+          if a.timer != TimerId(0):
+            loop.cancelTimer(a.timer)
+            a.timer = TimerId(0)
+          if he.finished: return
+          if he.nextIdx >= he.addrs.len:
+            for o in he.attempts:
+              if not o.dead: return
+            failAll()
+
+        proc reportSuccess(a: HeAttempt): bool {.closure.} =
+          if he.finished:
+            a.dead = true
+            if a.timer != TimerId(0):
+              loop.cancelTimer(a.timer)
+              a.timer = TimerId(0)
+            return false
+          he.finished = true
+          if he.staggerTimer != TimerId(0):
+            loop.cancelTimer(he.staggerTimer)
+            he.staggerTimer = TimerId(0)
+          for o in he.attempts:
+            if o != a and not o.dead:
+              o.dead = true
+              if o.timer != TimerId(0):
+                loop.cancelTimer(o.timer)
+                o.timer = TimerId(0)
+              if o.conn != nil:
+                o.conn.closeAndRelease()
+                o.conn = nil
+          a.dead = true
+          if a.timer != TimerId(0):
+            loop.cancelTimer(a.timer)
+            a.timer = TimerId(0)
+          return true
+
+        proc armTimeout(a: HeAttempt) {.closure.} =
+          a.timer = loop.addTimer(ConnectTimeoutMs) do (id: int):
+            a.timer = TimerId(0)
+            if a.dead or he.finished: return
+            if a.conn != nil:
+              a.conn.closeAndRelease()
+              a.conn = nil
+            attemptDead(a)
+
+        proc startOne(idx: int) {.closure.} =
+          let addrBuf = he.addrs[idx]
+          let a = HeAttempt(idx: idx)
+          he.attempts.add(a)
+
+          let fd = socket(cast[ptr Sockaddr](addr addrBuf).sa_family.cint,
+                          SOCK_STREAM, 0)
+          if fd.cint < 0:
+            attemptDead(a)
+            return
+
+          setNonBlocking(fd)
+          setTcpNoDelay(fd)
+
+          let conn = Connection(
+            fd:        fd,
+            loop:      loop,
+            state:     Connecting,
+            readBuf:   acquireBuf(loop),
+            readBufLen: DefaultBufSize,
+          )
+
+          let sLen = getSockLen(addr addrBuf)
+          let ret = connect(fd, cast[ptr Sockaddr](addr addrBuf), sLen)
+          if ret < 0 and not sockInProgress():
+            conn.closeAndRelease()
+            attemptDead(a)
+            return
+
+          a.conn = conn
+
+          if ret == 0:
+            if reportSuccess(a):
+              conn.state = Connected
+              conn.loop.register(fd.int, {Read}) do (rfd: int, ev: set[EventType]):
+                if Error in ev:
+                  conn.closeAndRelease()
+                  if onClose != nil: onClose(conn)
+                  return
+                if conn.tlsState == TlsHandshaking:
+                  if not conn.driveHandshake():
+                    return
+                if Write in ev:
+                  if conn.flushWriteBuffer():
+                    if conn.closeAfterFlush:
+                      conn.closeAndRelease()
+                      if onClose != nil: onClose(conn)
+                      return
+                    if conn.state == Connected:
+                      conn.loop.modify(rfd, {Read})
+                if Read in ev or Hup in ev:
+                  conn.handleClientRead(onData, onClose)
+                if Hup in ev and conn.state == Connected:
+                  conn.closeAndRelease()
+                  if onClose != nil: onClose(conn)
+              onConnect(conn)
+              if conn.state == Closed: return
+            else:
+              conn.closeAndRelease()
+            return
+
+          conn.loop.register(fd.int, {Write}) do (wfd: int, ev: set[EventType]):
+            conn.loop.unregister(wfd)
+            if conn.fd.int != wfd:
+              return
+            if Error in ev:
+              conn.closeAndRelease()
+              attemptDead(a)
+              return
+            var err: cint = 0
+            var errLen: SockLen = sizeof(err).SockLen
+            discard getsockopt(fd, SOL_SOCKET, SO_ERROR, addr err, addr errLen)
+            if err != 0:
+              conn.closeAndRelease()
+              attemptDead(a)
+              return
+
+            if reportSuccess(a):
+              conn.state = Connected
+              setTcpNoDelay(SocketHandle(wfd))
+              conn.loop.register(wfd, {Read}) do (rfd: int, ev: set[EventType]):
+                if Error in ev:
+                  conn.closeAndRelease()
+                  if onClose != nil: onClose(conn)
+                  return
+                if conn.tlsState == TlsHandshaking:
+                  if not conn.driveHandshake():
+                    return
+                if Write in ev:
+                  if conn.flushWriteBuffer():
+                    if conn.closeAfterFlush:
+                      conn.closeAndRelease()
+                      if onClose != nil: onClose(conn)
+                      return
+                    if conn.state == Connected:
+                      conn.loop.modify(rfd, {Read})
+                if Read in ev or Hup in ev:
+                  conn.handleClientRead(onData, onClose)
+                if Hup in ev and conn.state == Connected:
+                  conn.closeAndRelease()
+                  if onClose != nil: onClose(conn)
+              onConnect(conn)
+              if conn.state == Closed: return
+            else:
+              conn.closeAndRelease()
+          armTimeout(a)
+
+        proc armStagger() {.closure.} =
+          he.staggerTimer = loop.addTimer(ConnectionAttemptDelayMs) do (id: int):
+            he.staggerTimer = TimerId(0)
+            if he.finished: return
+            if he.nextIdx < he.addrs.len:
+              let i = he.nextIdx
+              inc he.nextIdx
+              startOne(i)
+              if he.nextIdx < he.addrs.len:
+                armStagger()
+
+        he.nextIdx = 1
+        startOne(0)
+        if not he.finished and he.nextIdx < he.addrs.len:
+          armStagger()
     )
 
   when not defined(windows):

--- a/src/powpow/proto/ratelimit.nim
+++ b/src/powpow/proto/ratelimit.nim
@@ -6,15 +6,16 @@
 
 ## Sliding-window rate limiter built on powpow's event loop.
 ##
-## Usage:
-##   let server = newHttpServer()
-##   let rl = newRateLimiter(server.getLoop(), maxRequests = 100, windowMs = 60_000)
-##   server.handler = proc(req: HttpRequest, res: HttpResponse) {.gcsafe.} =
-##     if not rl.check(req, res): return
-##     res.status(Http200).send("Hello!")
+## Supports multiple time windows per limiter — e.g. per-IP hourly + daily
+## quotas checked atomically. The two-phase `allow` verifies every window
+## before incrementing any, so a message rejected by the daily quota is not
+## overcounted against the hourly.
 ##
-
-import std/[tables, monotimes, httpcore]
+## Single-window (backward-compatible):
+##   let rl = newRateLimiter(loop, maxRequests = 100, windowMs = 60_000)
+##
+## Multi-window:
+##   let rl = newMultiRateLimiter(loop, [(100, 3_600_000), (1_000, 86_400_000)])
 
 import std/[tables, monotimes, httpcore, locks]
 
@@ -28,39 +29,56 @@ proc monoMs: int64 {.inline.} = getMonoTime().ticks div 1_000_000
 type
   Bucket = tuple[start: int64, count: int]
 
+  WindowLimit* = tuple[maxRequests: int, windowMs: int]
+
+  KeyState = object
+    buckets: seq[Bucket]
+    lastSeen: int64
+
   RateLimiter* = ref object
     loop*: Loop
-    buckets: Table[string, Bucket]
-    maxRequests: int
-    windowMs: int64
+    limits: seq[WindowLimit]
+    states: Table[string, KeyState]
     cleanupTimer: TimerId
-    lock: Lock   # guards `buckets` — the limiter may be shared across workers
+    lock: Lock   # guards `states` — the limiter may be shared across workers
+
+# ── Constructors ──────────────────────────────────────────────────────────────
+
+proc newMultiRateLimiter*(loop: Loop; limits: openArray[WindowLimit];
+                         enableCleanup = true): RateLimiter =
+  ## Create a sliding-window rate limiter with one or more time windows.
+  ## Each `limit` is `(maxRequests, windowMs)` — entries with `maxRequests`
+  ## <= 0 are treated as unlimited (always allowed, never counted).
+  let rl = RateLimiter(
+    loop: loop,
+    limits: @limits,
+    states: initTable[string, KeyState](64),
+  )
+  initLock(rl.lock)
+  if enableCleanup and limits.len > 0:
+    # find the largest window for the sweep interval
+    var maxWindowMs: int64
+    for lim in limits:
+      if lim.windowMs > maxWindowMs:
+        maxWindowMs = lim.windowMs
+    if maxWindowMs > 0:
+      let sweepMs = maxWindowMs div 2
+      rl.cleanupTimer = loop.addInterval(max(sweepMs, 1000)) do (id: int):
+        withLock rl.lock:
+          let now = monoMs()
+          let maxAge = maxWindowMs * 2
+          var stale: seq[string]
+          for k, s in rl.states:
+            if now - s.lastSeen > maxAge:
+              stale.add(k)
+          for k in stale:
+            rl.states.del(k)
+  result = rl
 
 proc newRateLimiter*(loop: Loop; maxRequests: int; windowMs: int;
                      enableCleanup = true): RateLimiter =
-  ## Create a sliding-window rate limiter. `maxRequests` per `windowMs`
-  ## per unique client IP. When `enableCleanup` is true (default), a
-  ## periodic timer sweeps stale buckets from memory.
-  let rl = RateLimiter(
-    loop: loop,
-    maxRequests: maxRequests,
-    windowMs: windowMs.int64,
-    buckets: initTable[string, Bucket](64),
-  )
-  initLock(rl.lock)
-  if enableCleanup and windowMs > 0:
-    let sweepMs = windowMs div 2
-    rl.cleanupTimer = loop.addInterval(max(sweepMs, 1000)) do (id: int):
-      withLock rl.lock:
-        let now = monoMs()
-        let maxAge = rl.windowMs * 2
-        var stale: seq[string]
-        for ip, bucket in rl.buckets:
-          if now - bucket.start > maxAge:
-            stale.add(ip)
-        for ip in stale:
-          rl.buckets.del(ip)
-  result = rl
+  ## Single-window convenience constructor (backward-compatible).
+  newMultiRateLimiter(loop, [(maxRequests, windowMs)], enableCleanup)
 
 proc close*(rl: RateLimiter) =
   ## Stop the cleanup timer and release the limiter's lock.
@@ -69,19 +87,56 @@ proc close*(rl: RateLimiter) =
     rl.cleanupTimer = TimerId(0)
   deinitLock(rl.lock)
 
-proc allow*(rl: RateLimiter; ip: string): bool =
-  if ip.len == 0 or rl.maxRequests <= 0:
+# ── Core allow ────────────────────────────────────────────────────────────────
+
+proc allow*(rl: RateLimiter; key: string): bool =
+  ## Check whether `key` is allowed across ALL configured windows.  Returns
+  ## true only when every non-unlimited window still has capacity; increments
+  ## the count atomically on success.  Returns true immediately for empty keys
+  ## or when every rule is unlimited (`maxRequests <= 0`).
+  if key.len == 0:
     return true
+  var allUnlimited = true
+  for lim in rl.limits:
+    if lim.maxRequests > 0:
+      allUnlimited = false
+      break
+  if allUnlimited:
+    return true
+
   withLock rl.lock:
     let now = monoMs()
-    var bucket = rl.buckets.getOrDefault(ip, (now, 0))
-    if now - bucket.start > rl.windowMs:
-      bucket = (now, 0)
-    inc bucket.count
-    if bucket.count > rl.maxRequests:
-      return false
-    rl.buckets[ip] = bucket
+    var state: KeyState
+    if key in rl.states:
+      state = rl.states[key]
+      state.buckets.setLen(rl.limits.len)
+    else:
+      state = KeyState(buckets: newSeq[Bucket](rl.limits.len), lastSeen: 0)
+
+    # Phase 1 — verify every window has capacity.
+    for i in 0 ..< rl.limits.len:
+      let lim = rl.limits[i]
+      if lim.maxRequests <= 0:
+        continue
+      var bucket = state.buckets[i]
+      if now - bucket.start > lim.windowMs:
+        bucket = (now, 0)
+      if bucket.count >= lim.maxRequests:
+        return false          # reject — nothing was incremented
+      state.buckets[i] = bucket
+
+    # Phase 2 — all passed; increment every non-unlimited window.
+    for i in 0 ..< rl.limits.len:
+      let lim = rl.limits[i]
+      if lim.maxRequests <= 0:
+        continue
+      inc state.buckets[i].count
+
+    state.lastSeen = now
+    rl.states[key] = state
     return true
+
+# ── HTTP convenience ──────────────────────────────────────────────────────────
 
 proc check*(rl: RateLimiter; req: HttpRequest; res: HttpResponse): bool {.inline.} =
   if not rl.allow(req.getClientIp()):

--- a/tests/test_ratelimit_multi.nim
+++ b/tests/test_ratelimit_multi.nim
@@ -1,0 +1,103 @@
+## tests/test_ratelimit_multi.nim — Multi-window RateLimiter tests.
+##
+## Compile/run with: `clue build tests/test_ratelimit_multi.nim && ./test_ratelimit_multi`
+
+import std/[unittest]
+import ../src/powpow
+
+let loop = newLoop()
+
+test "multi-window: atomic pass — all windows increment":
+  # Window A: max 3, Window B: max 2 — B fills first
+  let rl = newMultiRateLimiter(loop, [(3, 3_600_000), (2, 3_600_000)],
+                              enableCleanup = false)
+  check rl.allow("alice") == true   # A=1, B=1
+  check rl.allow("alice") == true   # A=2, B=2
+  check rl.allow("alice") == false  # B full → reject, A stays at 2
+  # Verify atomicity: third call rejected by B didn't increment A
+  # (if A had incremented, the key would be at A=3)
+  # Now use a fresh key with B=2 limit to prove B is full:
+  let rl2 = newMultiRateLimiter(loop, [(3, 3_600_000), (2, 3_600_000)],
+                                enableCleanup = false)
+  check rl2.allow("a") == true
+  check rl2.allow("a") == true
+  check rl2.allow("a") == false
+  # With A=3,B=2: 2 calls fill B, 3rd rejected; A should allow 1 more
+  check rl2.allow("b") == true   # fresh key B=1
+  check rl2.allow("b") == true   # B=2 (full)
+  check rl2.allow("b") == false  # B full
+  rl.close()
+  rl2.close()
+
+test "multi-window: reject blocks all — no partial increment":
+  # A=5, B=1 (tiny daily)
+  let rl = newMultiRateLimiter(loop, [(5, 3_600_000), (1, 3_600_000)],
+                              enableCleanup = false)
+  check rl.allow("bob") == true    # A=1, B=1
+  check rl.allow("bob") == false   # B full → reject, A stays at1
+  check rl.allow("bob") == false   # still rejected
+  # Verify A didn't overcount by using a fresh key with B=1:
+  let rl2 = newMultiRateLimiter(loop, [(5, 3_600_000), (1, 3_600_000)],
+                                enableCleanup = false)
+  check rl2.allow("x") == true
+  check rl2.allow("x") == false    # B full
+  check rl2.allow("y") == true     # fresh key — proves A didn't affect y
+  rl.close()
+  rl2.close()
+
+test "multi-window: unlimited rule skipped":
+  let rl = newMultiRateLimiter(loop, [(0, 3_600_000), (2, 3_600_000)],
+                              enableCleanup = false)
+  # Unlimited A (maxRequests=0), limited B (maxRequests=2)
+  check rl.allow("dave") == true
+  check rl.allow("dave") == true
+  check rl.allow("dave") == false  # B full
+  # Third call rejected by B; verify unlimited A didn't block:
+  check rl.allow("frank") == true  # fresh key, unlimited A always passes
+  check rl.allow("frank") == true
+  check rl.allow("frank") == false # B full for frank too
+  rl.close()
+
+test "multi-window: independent keys don't interfere":
+  let rl = newMultiRateLimiter(loop, [(1, 3_600_000)],
+                              enableCleanup = false)
+  check rl.allow("A") == true
+  check rl.allow("B") == true     # different key, fresh bucket
+  check rl.allow("A") == false    # A exhausted
+  check rl.allow("B") == false    # B also exhausted (max=1)
+  # Fresh key:
+  check rl.allow("C") == true
+  check rl.allow("C") == false
+  rl.close()
+
+test "single-window backward compat":
+  let rl = newRateLimiter(loop, maxRequests = 2, windowMs = 60_000,
+                          enableCleanup = false)
+  check rl.allow("x") == true
+  check rl.allow("x") == true
+  check rl.allow("x") == false
+  # Verify count=2 by using fresh key at same limit:
+  let rl2 = newRateLimiter(loop, maxRequests = 2, windowMs = 60_000,
+                           enableCleanup = false)
+  check rl2.allow("y") == true
+  check rl2.allow("y") == true
+  check rl2.allow("y") == false
+  rl.close()
+  rl2.close()
+
+test "all-unlimited returns true without recording":
+  let rl = newMultiRateLimiter(loop, [(0, 3_600_000), (0, 86_400_000)],
+                              enableCleanup = false)
+  check rl.allow("anyone") == true
+  # Call again — still unlimited
+  check rl.allow("anyone") == true
+  rl.close()
+
+test "empty key always allowed":
+  let rl = newMultiRateLimiter(loop, [(1, 3_600_000)],
+                              enableCleanup = false)
+  check rl.allow("") == true
+  check rl.allow("") == true
+  rl.close()
+
+loop.close()


### PR DESCRIPTION
- dns.nim: MX record support (readName codec, resolveMxAsync) + concurrent AAAA+A resolution merged IPv6-first (resolveAddrBothAsync)
- tcp.nim: connectHe implements RFC 6555 — 250ms-staggered parallel attempts, first CONNECT wins; original sequential connect preserved
- ratelimit.nim: newMultiRateLimiter verifies every window atomically before incrementing any; single-window API backward-compatible